### PR TITLE
add daily trivy scan workflow

### DIFF
--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -1,0 +1,55 @@
+name: Scan vulnerabilities
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  scan_lvp_files_systems:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run Trivy vulnerability scanner in repo mode
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  scan_lvp_docker_image:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/setup-go@v2.1.5
+        with:
+          go-version: "1.17.2"
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build local-volume-provider image from Dockerfile
+        run: |
+          docker build --pull -t replicated/local-volume-provider:${{ github.sha }} -f deploy/local-volume-provider/Dockerfile --build-arg VERSION=${{ github.sha }} .
+          
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'replicated/local-volume-provider:${{ github.sha }}'
+          format: 'sarif'          
+          output: 'trivy-results.sarif'
+          ignore-unfixed: true
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,12 @@ build-dirs:
 clean:
 	@echo "cleaning"
 	rm -rf _output
+
+.PHONY: scan
+scan:
+	trivy fs \
+		--security-checks vuln \
+		--exit-code=1 \
+		--severity="HIGH,CRITICAL" \
+		--ignore-unfixed \
+		./


### PR DESCRIPTION
This PR adds a daily cron GitHub workflow to scan the LVP image and filesystem.  It also adds a `make scan` command so that the filesystem scan can easily be run locally.