### PR TITLE
use debian bullseye base image

### DIFF
--- a/deploy/local-volume-provider/Dockerfile
+++ b/deploy/local-volume-provider/Dockerfile
@@ -22,7 +22,7 @@ COPY pkg ./pkg
 ARG VERSION=main
 RUN CGO_ENABLED=0 go build -ldflags=" -X github.com/replicatedhq/local-volume-provider/pkg/version.version=$VERSION " -o /go/bin/local-volume-fileserver ./cmd/local-volume-fileserver
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN mkdir /plugins
 COPY --from=build-plugin /go/bin/local-volume-provider /plugins/
 COPY --from=build-fileserver /go/bin/local-volume-fileserver .


### PR DESCRIPTION
This PR updates the base image to `debian:bullseye-slim` to keep the base image up-to-date with the latest stable os version and resolves CVE-2022-29458 with high severity.