### PR TITLE
set securityContext on restic daemonset

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,19 @@
+name: unit-tests
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.19
+    - name: Run unit tests
+      run: |
+        make test

--- a/pkg/plugin/kubernetes_test.go
+++ b/pkg/plugin/kubernetes_test.go
@@ -10,14 +10,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/utils/pointer"
 )
 
 // test ensureResources function
 func Test_ensureResources(t *testing.T) {
 	tests := []struct {
-		name string
-		opts EnsureResourcesOpts
-		want *appsv1.Deployment
+		name           string
+		opts           EnsureResourcesOpts
+		wantDeployment *appsv1.Deployment
+		wantDaemonSet  *appsv1.DaemonSet
 	}{
 		{
 			name: "new configuration -- local-volume-provider container is added to the deployment along with the volume",
@@ -70,7 +72,7 @@ func Test_ensureResources(t *testing.T) {
 				volumeType: Hostpath,
 				log:        logrus.NewEntry(logrus.New()),
 			},
-			want: &appsv1.Deployment{
+			wantDeployment: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
 					Kind:       "Deployment",
@@ -85,6 +87,7 @@ func Test_ensureResources(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name: "velero",
+									Env:  getVeleroContainerEnv(),
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "plugins",
@@ -97,7 +100,10 @@ func Test_ensureResources(t *testing.T) {
 									},
 								},
 								{
-									Name: "local-volume-provider",
+									Name:    "local-volume-provider",
+									Image:   "replicated/local-volume-provider:main",
+									Command: []string{"/local-volume-fileserver"},
+									Env:     getLVPContainerEnv(),
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "my-bucket",
@@ -146,6 +152,7 @@ func Test_ensureResources(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name: "velero",
+										Env:  getVeleroContainerEnv(),
 										VolumeMounts: []corev1.VolumeMount{
 											{
 												Name:      "plugins",
@@ -158,7 +165,10 @@ func Test_ensureResources(t *testing.T) {
 										},
 									},
 									{
-										Name: "local-volume-provider",
+										Name:    "local-volume-provider",
+										Image:   "replicated/local-volume-provider:main",
+										Command: []string{"/local-volume-fileserver"},
+										Env:     getLVPContainerEnv(),
 										VolumeMounts: []corev1.VolumeMount{
 											{
 												Name:      "my-bucket",
@@ -201,7 +211,7 @@ func Test_ensureResources(t *testing.T) {
 				volumeType: Hostpath,
 				log:        logrus.NewEntry(logrus.New()),
 			},
-			want: &appsv1.Deployment{
+			wantDeployment: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
 					Kind:       "Deployment",
@@ -216,6 +226,7 @@ func Test_ensureResources(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name: "velero",
+									Env:  getVeleroContainerEnv(),
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "plugins",
@@ -232,7 +243,10 @@ func Test_ensureResources(t *testing.T) {
 									},
 								},
 								{
-									Name: "local-volume-provider",
+									Name:    "local-volume-provider",
+									Image:   "replicated/local-volume-provider:main",
+									Command: []string{"/local-volume-fileserver"},
+									Env:     getLVPContainerEnv(),
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "my-bucket",
@@ -294,6 +308,7 @@ func Test_ensureResources(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name: "velero",
+										Env:  getVeleroContainerEnv(),
 										VolumeMounts: []corev1.VolumeMount{
 											{
 												Name:      "plugins",
@@ -306,7 +321,10 @@ func Test_ensureResources(t *testing.T) {
 										},
 									},
 									{
-										Name: "local-volume-provider",
+										Name:    "local-volume-provider",
+										Image:   "replicated/local-volume-provider:main",
+										Command: []string{"/local-volume-fileserver"},
+										Env:     getLVPContainerEnv(),
 										VolumeMounts: []corev1.VolumeMount{
 											{
 												Name:      "my-bucket",
@@ -353,7 +371,7 @@ func Test_ensureResources(t *testing.T) {
 				volumeType: Hostpath,
 				log:        logrus.NewEntry(logrus.New()),
 			},
-			want: &appsv1.Deployment{
+			wantDeployment: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
 					Kind:       "Deployment",
@@ -368,6 +386,7 @@ func Test_ensureResources(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name: "velero",
+									Env:  getVeleroContainerEnv(),
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "plugins",
@@ -380,7 +399,10 @@ func Test_ensureResources(t *testing.T) {
 									},
 								},
 								{
-									Name: "local-volume-provider",
+									Name:    "local-volume-provider",
+									Image:   "replicated/local-volume-provider:main",
+									Command: []string{"/local-volume-fileserver"},
+									Env:     getLVPContainerEnv(),
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "my-new-bucket",
@@ -429,6 +451,7 @@ func Test_ensureResources(t *testing.T) {
 								Containers: []corev1.Container{
 									{
 										Name: "velero",
+										Env:  getVeleroContainerEnv(),
 										VolumeMounts: []corev1.VolumeMount{
 											{
 												Name:      "plugins",
@@ -441,7 +464,10 @@ func Test_ensureResources(t *testing.T) {
 										},
 									},
 									{
-										Name: "local-volume-provider",
+										Name:    "local-volume-provider",
+										Image:   "replicated/local-volume-provider:main",
+										Command: []string{"/local-volume-fileserver"},
+										Env:     getLVPContainerEnv(),
 										VolumeMounts: []corev1.VolumeMount{
 											{
 												Name:      "my-bucket",
@@ -488,7 +514,7 @@ func Test_ensureResources(t *testing.T) {
 				volumeType: Hostpath,
 				log:        logrus.NewEntry(logrus.New()),
 			},
-			want: &appsv1.Deployment{
+			wantDeployment: &appsv1.Deployment{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
 					Kind:       "Deployment",
@@ -503,6 +529,7 @@ func Test_ensureResources(t *testing.T) {
 							Containers: []corev1.Container{
 								{
 									Name: "velero",
+									Env:  getVeleroContainerEnv(),
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "plugins",
@@ -515,7 +542,10 @@ func Test_ensureResources(t *testing.T) {
 									},
 								},
 								{
-									Name: "local-volume-provider",
+									Name:    "local-volume-provider",
+									Image:   "replicated/local-volume-provider:main",
+									Command: []string{"/local-volume-fileserver"},
+									Env:     getLVPContainerEnv(),
 									VolumeMounts: []corev1.VolumeMount{
 										{
 											Name:      "my-bucket",
@@ -546,20 +576,284 @@ func Test_ensureResources(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "updated configuration -- pod security context is set on the deployment and daemonset",
+			opts: EnsureResourcesOpts{
+				clientset: fake.NewSimpleClientset(
+					&appsv1.Deployment{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind:       "Deployment",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "velero",
+							Namespace: "velero",
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name: "velero",
+											Env:  getVeleroContainerEnv(),
+											VolumeMounts: []corev1.VolumeMount{
+												{
+													Name:      "plugins",
+													MountPath: "/plugins",
+												},
+												{
+													Name:      "my-bucket",
+													MountPath: "/var/velero-local-volume-provider/my-bucket",
+												},
+											},
+										},
+										{
+											Name:    "local-volume-provider",
+											Image:   "replicated/local-volume-provider:main",
+											Command: []string{"/local-volume-fileserver"},
+											Env:     getLVPContainerEnv(),
+											VolumeMounts: []corev1.VolumeMount{
+												{
+													Name:      "my-bucket",
+													MountPath: "/var/velero-local-volume-provider/my-bucket",
+												},
+											},
+										},
+									},
+									Volumes: []corev1.Volume{
+										{
+											Name: "plugins",
+											VolumeSource: corev1.VolumeSource{
+												EmptyDir: &corev1.EmptyDirVolumeSource{},
+											},
+										},
+										{
+											Name: "my-bucket",
+											VolumeSource: corev1.VolumeSource{
+												HostPath: &corev1.HostPathVolumeSource{
+													Path: "/backups",
+													Type: hostPathTypePtr(corev1.HostPathDirectory),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					&appsv1.DaemonSet{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: "v1",
+							Kind:       "DaemonSet",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "restic",
+							Namespace: "velero",
+						},
+						Spec: appsv1.DaemonSetSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name: "restic",
+											VolumeMounts: []corev1.VolumeMount{
+												{
+													Name:      "my-bucket",
+													MountPath: "/var/velero-local-volume-provider/my-bucket",
+												},
+											},
+										},
+									},
+									Volumes: []corev1.Volume{
+										{
+											Name: "my-bucket",
+											VolumeSource: corev1.VolumeSource{
+												HostPath: &corev1.HostPathVolumeSource{
+													Path: "/backups",
+													Type: hostPathTypePtr(corev1.HostPathDirectory),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				),
+				namespace: "velero",
+				bucket:    "my-bucket",
+				prefix:    "",
+				path:      "/var/velero-local-volume-provider/my-bucket",
+				config: map[string]string{
+					"bucket": "my-bucket",
+					"prefix": "",
+					"path":   "/backups",
+				},
+				pluginOpts: &localVolumeObjectStoreOpts{
+					securityContextRunAsUser:  "1001",
+					securityContextRunAsGroup: "1001",
+					securityContextFSGroup:    "2001",
+				},
+				volumeType: Hostpath,
+				log:        logrus.NewEntry(logrus.New()),
+			},
+			wantDeployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "velero",
+					Namespace: "velero",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "velero",
+									Env:  getVeleroContainerEnv(),
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "plugins",
+											MountPath: "/plugins",
+										},
+										{
+											Name:      "my-bucket",
+											MountPath: "/var/velero-local-volume-provider/my-bucket",
+										},
+									},
+								},
+								{
+									Name:    "local-volume-provider",
+									Image:   "replicated/local-volume-provider:main",
+									Command: []string{"/local-volume-fileserver"},
+									Env:     getLVPContainerEnv(),
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "my-bucket",
+											MountPath: "/var/velero-local-volume-provider/my-bucket",
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "plugins",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
+									},
+								},
+								{
+									Name: "my-bucket",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/backups",
+											Type: hostPathTypePtr(corev1.HostPathDirectory),
+										},
+									},
+								},
+							},
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:  pointer.Int64Ptr(1001),
+								RunAsGroup: pointer.Int64Ptr(1001),
+								FSGroup:    pointer.Int64Ptr(2001),
+							},
+						},
+					},
+				},
+			},
+			wantDaemonSet: &appsv1.DaemonSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "DaemonSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "restic",
+					Namespace: "velero",
+				},
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "restic",
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "my-bucket",
+											MountPath: "/var/velero-local-volume-provider/my-bucket",
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "my-bucket",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/backups",
+											Type: hostPathTypePtr(corev1.HostPathDirectory),
+										},
+									},
+								},
+							},
+							SecurityContext: &corev1.PodSecurityContext{
+								RunAsUser:  pointer.Int64Ptr(1001),
+								RunAsGroup: pointer.Int64Ptr(1001),
+								FSGroup:    pointer.Int64Ptr(2001),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := ensureResources(tt.opts)
 			require.NoError(t, err)
 
-			got, err := tt.opts.clientset.AppsV1().Deployments("velero").Get(context.TODO(), "velero", metav1.GetOptions{})
-			require.NoError(t, err)
+			if tt.wantDeployment != nil {
+				got, err := tt.opts.clientset.AppsV1().Deployments("velero").Get(context.TODO(), "velero", metav1.GetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, tt.wantDeployment.Spec.Template.Spec, got.Spec.Template.Spec)
+			}
 
-			require.ElementsMatch(t, tt.want.Spec.Template.Spec.Volumes, got.Spec.Template.Spec.Volumes)
-
-			for idx, container := range tt.want.Spec.Template.Spec.Containers {
-				require.ElementsMatch(t, container.VolumeMounts, got.Spec.Template.Spec.Containers[idx].VolumeMounts)
+			if tt.wantDaemonSet != nil {
+				got, err := tt.opts.clientset.AppsV1().DaemonSets("velero").Get(context.TODO(), "restic", metav1.GetOptions{})
+				require.NoError(t, err)
+				require.Equal(t, tt.wantDaemonSet.Spec.Template.Spec, got.Spec.Template.Spec)
 			}
 		})
+	}
+}
+
+func getVeleroContainerEnv() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name: "POD_IP",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.podIP",
+				},
+			},
+		},
+	}
+}
+
+func getLVPContainerEnv() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "MOUNT_POINT",
+			Value: getRoot(),
+		},
+		{
+			Name: "VELERO_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
[SC-61164](https://app.shortcut.com/replicated/story/61164/hostpath-nfs-snapshots-fail-when-minio-is-disabled-aka-local-volume-provider-is-used-due-to-directory-permission-issues)

This PR makes it so that the local-volume-provider plugin will set the pod `securityContext` for the restic daemonset in the same way it does for the velero deployment.  This fixes an issue where NFS snapshots would fail with the following permissions error:
```
Error backing up item" backup=velero/instance-zpqzs error="pod volume backup failed: running Restic backup, stderr=Fatal: unable to open repo at /var/velero-local-volume-provider/velero-lvp-a344e67747d8/restic/default: ReadDir: open /var/velero-local-volume-provider/velero-lvp-a344e67747d8/restic/default/keys: permission denied\n: exit status 1
```

Adds a unit test to validate the security context and a unit test workflow that runs on PR to assist review.