### PR TITLE
If user is 0, they should be able to write to any groups

### DIFF
--- a/pkg/plugin/util.go
+++ b/pkg/plugin/util.go
@@ -67,7 +67,7 @@ func isWriteable(log *logrus.Entry, info fs.FileInfo) bool {
 	log.Debugf("Detected Gid: %d", os.Getegid())
 
 	// Writable by group
-	if info.Mode().Perm()&(1<<4) > 0 && os.Getegid() == int(stat.Gid) {
+	if info.Mode().Perm()&(1<<4) > 0 && os.Getegid() == int(stat.Gid) || os.Getegid() == 0 {
 		return true
 	}
 


### PR DESCRIPTION
debugging an install in crc.dev environment and blocked by directory is writable check despite running as gid 0.

```sh
❯ alias db_multip
db_multip='docker buildx build --platform linux/amd64,linux/arm64 --tag $(ghcr_tag) --push'

~/git/local-volume-provider writeUser0
❯ alias ghcr_tag
ghcr_tag='echo ghcr.io/kaovilai/$(basename $PWD):$(current-branch)'

~/git/local-volume-provider writeUser0
❯ alias current-branch
current-branch='git branch --show-current'

~/git/local-volume-provider writeUser0
❯ db_multip -f deploy/Dockerfile .
```

`ghcr.io/kaovilai/local-volume-provider:writeUser0`

for testing https://github.com/vmware-tanzu/velero/pull/8358