### PR TITLE
Speedup multiarch using cross arch builds.

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:1.20-bullseye AS build-plugin
+FROM --platform=$BUILDPLATFORM golang:1.22-bullseye AS build-plugin
 ENV GOPROXY=https://proxy.golang.org
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/local-volume-provider/local-volume-fileserver
+ARG TARGETARCH
+ARG BUILDPLATFORM
 WORKDIR $PROJECTPATH
 COPY Makefile ./
 COPY go.mod ./
@@ -8,9 +10,9 @@ COPY go.sum ./
 COPY cmd ./cmd
 COPY pkg ./pkg
 ARG VERSION=main
-RUN CGO_ENABLED=0 go build -ldflags=" -X github.com/replicatedhq/local-volume-provider/pkg/version.version=$VERSION " -o /go/bin/local-volume-provider ./cmd/local-volume-provider
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -ldflags=" -X github.com/replicatedhq/local-volume-provider/pkg/version.version=$VERSION " -o /go/bin/local-volume-provider ./cmd/local-volume-provider
 
-FROM golang:1.20-bullseye as build-fileserver
+FROM --platform=$BUILDPLATFORM golang:1.22-bullseye AS build-fileserver
 ENV GOPROXY=https://proxy.golang.org
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/local-volume-provider/local-volume-fileserver
 WORKDIR $PROJECTPATH
@@ -20,7 +22,7 @@ COPY go.sum ./
 COPY cmd ./cmd
 COPY pkg ./pkg
 ARG VERSION=main
-RUN CGO_ENABLED=0 go build -ldflags=" -X github.com/replicatedhq/local-volume-provider/pkg/version.version=$VERSION " -o /go/bin/local-volume-fileserver ./cmd/local-volume-fileserver
+RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -ldflags=" -X github.com/replicatedhq/local-volume-provider/pkg/version.version=$VERSION " -o /go/bin/local-volume-fileserver ./cmd/local-volume-fileserver
 
 FROM debian:bullseye-slim
 RUN mkdir /plugins


### PR DESCRIPTION
This also fixes issue with CGO in my env seen in #65 

Had to bump go version to build image successfully due to go.mod of this repo being 1.22 from a recent dependabot that did not bump Dockerfile.