### PR TITLE
Add docker image ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,13 @@
+name: Docker Image CI
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . -f deploy/Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,4 +10,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . -f deploy/Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . -f deploy/Dockerfile --tag replicated/local-volume-provider:$(date +%s)


### PR DESCRIPTION
Prevent https://github.com/replicatedhq/local-volume-provider/pull/57 from introducing Dockerfile build breaking changes.

This PR is expected to fail until #66 merges which contains Dockerfile golang upgrade to go1.22.