### PR TITLE
Add pvc plugin label to config ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ metadata:
   labels:
     velero.io/plugin-config: ""
     replicated.com/nfs: ObjectStore
+    replicated.com/pvc: ObjectStore
     replicated.com/hostpath: ObjectStore
 data:
   # Useful for local development


### PR DESCRIPTION
To allow for the pvc BSL to use custom image, the configmap needs to have pvc label.

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>
