### PR TITLE
Implement log downloading for fileserver fixes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ data:
   securityContextFsGroup: "1001"
   # If provided, will clean up all other volumes on the Velero and Node Agent pods
   preserveVolumes: "my-bucket,my-other-bucket"
+  # use this if you deployed an ingress for the fileserver running on 3000 to access logs from outside the cluster network
+  # e.g. via ur velero cli. You will need to deploy the service/ingress yourself. See examples/filserverService.yaml
+  externalDownloadHostname: "www.velero-logs.domain.com"
+  # using https currently seems not to be supported by the velero client
+  externalDownloadScheme: "http"
+  externalDownloadPort: 80
 ```
 
 ## Removing the plugin

--- a/examples/filserverService.yaml
+++ b/examples/filserverService.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fileserver
+  namespace: velero
+spec:
+  ports:
+    - name: fileserver
+      protocol: TCP
+      port: 3000
+      targetPort: 3000
+  selector:
+    app.kubernetes.io/instance: velero
+    app.kubernetes.io/name: velero
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster

--- a/examples/pluginConfigMap.yaml
+++ b/examples/pluginConfigMap.yaml
@@ -11,3 +11,9 @@ data:
   fileserverImage: ttl.sh/dans/local-volume-provider:12h
   securityContextRunAsUser: "1001"
   securityContextFsGroup: "1001"
+  # use this if you deployed an ingress for the fileserver running on 3000 to access logs from outside the cluster network
+  # e.g. via ur velero cli. You will need to deploy the service/ingress yourself. See examples/filserverService.yaml
+  externalDownloadHostname: "www.velero-logs.domain.com"
+  # using https currently seems not to be supported by the velero client
+  externalDownloadScheme: "http"
+  externalDownloadPort: 80

--- a/pkg/plugin/kubernetes.go
+++ b/pkg/plugin/kubernetes.go
@@ -25,6 +25,9 @@ type localVolumeObjectStoreOpts struct {
 	securityContextRunAsGroup string
 	securityContextFSGroup    string
 	preserveVolumes           map[string]bool
+	externalDownloadHostname  string
+	externalDownloadPort      string
+	externalDownloadScheme    string
 }
 
 const (
@@ -163,7 +166,7 @@ func ensureDeploymentHasVolume(deployment *appsv1.Deployment, volumeSpec *corev1
 		}
 		veleroContainer.VolumeMounts = append(veleroContainer.VolumeMounts, *volumeMountSpec)
 
-		// Add the POD_IP for servering the signed URLs
+		// Add the POD_IP for serving the signed URLs
 		if !containerHasEnvVar(veleroContainer, "POD_IP") {
 			veleroContainer.Env = append(veleroContainer.Env, corev1.EnvVar{
 				Name: "POD_IP",


### PR DESCRIPTION
This PR introduces the ability to download the velero logs via an ingress / external access.

For this new  (optional) plugin configurations are offered

```yaml
  externalDownloadHostname: "www.velero-logs.domain.com"
  # using https currently seems not to be supported by the velero client
  externalDownloadScheme: "http"
  externalDownloadPort: 80
```

Not setting those will default to the old behavior instructing the velero cli to download the logs using the internal pod ip of the fileserver (which always fails).

When providing those, including
- deploying a service for the fileserver (see `examples/fileserverService`)
- an ingress for this service, in our case here `www.velero-logs.domain.com`

You will be able to download the velero logs when running `velero backup logs manual1`.

You can test it yourself by using my test image `ghcr.io/eugenmayer/local-volume-provider:0.7.3`

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: local-volume-provider-config
  namespace: velero
  labels:
    velero.io/plugin-config: ""
    replicated.com/nfs: ObjectStore
    replicated.com/hostpath: ObjectStore
data:
  fileserverImage: ghcr.io/eugenmayer/local-volume-provider:0.7.3
  externalDownloadHostname: "www.velero-logs.domain.com"
  externalDownloadScheme: "http"
  externalDownloadPort: 80
```

## Known limitations

it seems like the velero cli is not able to download the logs from a TLS ingress (official signed LE certificate). it always fails with

```
An error occurred: request failed: Bad Request
```

Assuming this is a velero limitation right now