### PR TITLE
Use tcp instead of tcp4 network  config to support IPv6 bindling

### DIFF
--- a/cmd/local-volume-fileserver/main.go
+++ b/cmd/local-volume-fileserver/main.go
@@ -19,7 +19,9 @@ func main() {
 		os.Exit(0)
 	}
 
-	app := fiber.New()
+	app := fiber.New(fiber.Config{
+		Network: fiber.NetworkTCP,
+	})
 
 	mountPoint := os.Getenv("MOUNT_POINT")
 	if mountPoint == "" {


### PR DESCRIPTION
To support dual stack and IPv6 binding, we need to use tcp network config in fiber app. By default fiber app uses tcp4 which only binds to IPv4