### PR TITLE
Fix invalid runner label in daily scan workflow

### DIFF
--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -27,7 +27,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   scan_lvp_docker_image:
-    runs-on: -latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
## Summary

This PR fixes the runner label used by the `scan_lvp_docker_image` job in `.github/workflows/daily-scan.yaml`.

## Problem

The `Scan Vulnerabilities` workflow keeps getting stuck while waiting for a runner.

## Cause

The workflow used:

```yml
runs-on: -latest
```

This is syntactically valid YAML, but it does not appear to be a valid GitHub-hosted runner label. This PR changes it to:

```yml
runs-on: ubuntu-latest
```

## Background

This line seems to have been introduced by mistake during an earlier runner-label update ([This commit](https://github.com/replicatedhq/local-volume-provider/commit/44a92a203d8972b9cf0169571c7a360e439e3cbc)).
