### PR TITLE
Bump Go to 1.26.2 to fix CVE-2026-27143

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: "1.25"
+        go-version: "1.26"
     - name: Run unit tests
       run: |
         make test

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v6
       with:
-        go-version: "1.26"
+        go-version-file: 'go.mod'
     - name: Run unit tests
       run: |
         make test

--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -29,12 +29,12 @@ jobs:
   scan_lvp_docker_image:
     runs-on: -latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-
-      - name: Checkout
-        uses: actions/checkout@v6
 
       - uses: ./.github/actions/build-push-lvp-image
         with:

--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/daily-scan.yaml
+++ b/.github/workflows/daily-scan.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26"
+          go-version-file: 'go.mod'
 
       - name: Checkout
         uses: actions/checkout@v6

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS build-plugin
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS build-plugin
 ENV GOPROXY=https://proxy.golang.org
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/local-volume-provider/local-volume-fileserver
 ARG TARGETARCH
@@ -12,7 +12,7 @@ COPY pkg ./pkg
 ARG VERSION=main
 RUN CGO_ENABLED=0 GOARCH=${TARGETARCH} go build -ldflags=" -X github.com/replicatedhq/local-volume-provider/pkg/version.version=$VERSION " -o /go/bin/local-volume-provider ./cmd/local-volume-provider
 
-FROM --platform=$BUILDPLATFORM golang:1.25-bookworm AS build-fileserver
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm AS build-fileserver
 ENV GOPROXY=https://proxy.golang.org
 ENV PROJECTPATH=/go/src/github.com/replicatedhq/local-volume-provider/local-volume-fileserver
 WORKDIR $PROJECTPATH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/replicatedhq/local-volume-provider
 
-go 1.25.8
+go 1.26.2
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.12


### PR DESCRIPTION
Bumps Go from 1.25.8 to 1.26.2 to resolve CVE-2026-27143.\n\nChanges:\n- go.mod: go 1.25.8 -> 1.26.2\n- Dockerfile: golang:1.25-bookworm -> golang:1.26-bookworm\n- GitHub Actions: go-version 1.25 -> 1.26\n\nCVE-2026-27143 is a critical compiler vulnerability affecting Go versions < 1.25.9 and 1.26.0-1.26.1.