### PR TITLE
Update deploy workflow to avoid Node 20 deprecation warning

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v7
     - id: get_version
-      uses: battila7/get-version-action@v2
+      run: |
+        version="${GITHUB_REF_NAME#v}"
+        echo "version=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+        echo "version-without-v=$version" >> "$GITHUB_OUTPUT"
     - uses: ./.github/actions/build-push-lvp-image
       with:
         image-name: index.docker.io/replicated/local-volume-provider:${{ steps.get_version.outputs.version-without-v }}


### PR DESCRIPTION
GitHub is deprecating Node 20 for GitHub Actions runtimes. This PR updates the deploy workflow to remove the action that triggers the deprecation warning.

Changes:
- Replace `battila7/get-version-action@v2` (Node 12, forced to Node 24 with deprecation warning) with a native shell step using `GITHUB_REF_NAME`

This resolves the "Node.js 20 is deprecated" warning seen in recent deploy workflow runs.